### PR TITLE
one of the real-examples links expired and updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ For example test cases (the number of all supported cases should be bigger than 
 
 
 ### 2) Some real examples
-- https://chris-young.net/2017/04/12/pentest-ltd-ctf-securi-tay-2017-walkthrough/
+- https://chris-young.net/pentest-ltd-ctf-securi-tay-2017-walkthrough/
 - https://www.exploit-db.com/exploits/41892/
 - https://www.exploit-db.com/exploits/34461/
 


### PR DESCRIPTION
Primary reason for this change : "chris-young[.]net" had updated its page recently and the original doesn't direct to the right page anymore and does show `404`. 
Secondly, visitor can't wayback machine for the old url too. 
That's why I'm here to update the newest workable link for reference.